### PR TITLE
Add support for setting the rating value to undefined.

### DIFF
--- a/index.js
+++ b/index.js
@@ -176,12 +176,8 @@ module.exports = function rater(options) {
   }
 
   function setRating(value) {
-    if (typeof value === "undefined") {
-      throw new Error("Value not set.");
-    }
-
-    if (typeof value !== "number") {
-      throw new Error("Value must be a number.");
+    if (typeof value !== "number" && typeof value !== "undefined") {
+      throw new Error("Value must be a number or undefined.");
     }
 
     if (value < 0 || value > stars) {


### PR DESCRIPTION
Adds support for: setRating(undefined)

This is useful when you want to toggle between a value(let's say between 0-5) and no value, and you want to check if the value is set to a number or not(undefined). Checking for zero(0) doesn't work in those cases if you want to provide 0 stars as an option.